### PR TITLE
Fix crash when running on CPU

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ def parse_args():
     parser.add_argument('--train', action='store_true', help='train the segmentation model')
     parser.add_argument('--evaluate', action='store_true', help='evaluate the model')
     parser.add_argument('--segment', action='store_true', help='segment new files or input text')
-    parser.add_argument('--gpu', type=str, default='0', help='specify gpu device')
+    parser.add_argument('--gpu', type=str, help='specify gpu device')
 
     train_settings = parser.add_argument_group('train settings')
     train_settings.add_argument('--optim', default='adam', help='optimizer type')

--- a/src/run.py
+++ b/src/run.py
@@ -32,7 +32,8 @@ if __name__ == '__main__':
     logger.info('Running with args : {}'.format(args))
 
     os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-    os.environ["CUDA_VISIBLE_DEVICES"] = args.gpu
+    if args.gpu is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.gpu
 
     random.seed(args.seed)
     np.random.seed(args.seed)


### PR DESCRIPTION
This commit fixes the following crash when running `python run.py --input_files input.txt --segment` on CPU:
```
THCudaCheck FAIL file=/pytorch/aten/src/THC/THCGeneral.cpp line=51 error=30 : unknown error
Traceback (most recent call last):
  File "run.py", line 48, in <module>
    segment(args)
  File "/home/steven/code/AIA/n/src/api.py", line 134, in segment
    model = AttnSegModel(args, word_vocab)
  File "/home/steven/code/AIA/n/src/elmo_crf_seg.py", line 18, in __init__
    self.elmo = ElmoEmbedder(cuda_device=0 if args.gpu is not None else -1)
  File "/usr/local/lib/python3.6/dist-packages/allennlp/commands/elmo.py", line 166, in __init__
    self.elmo_bilm = self.elmo_bilm.cuda(device=cuda_device)
  File "/home/steven/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 260, in cuda
    return self._apply(lambda t: t.cuda(device))
  File "/home/steven/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 187, in _apply
    module._apply(fn)
  File "/home/steven/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 187, in _apply
    module._apply(fn)
  File "/home/steven/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 193, in _apply
    param.data = fn(param.data)
  File "/home/steven/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 260, in <lambda>
    return self._apply(lambda t: t.cuda(device))
  File "/home/steven/.local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 162, in _lazy_init
    torch._C._cuda_init()
RuntimeError: cuda runtime error (30) : unknown error at /pytorch/aten/src/THC/THCGeneral.cpp:51
```

